### PR TITLE
Use Esprima 1.0 stable version.

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "test"
   },
   "dependencies": {
-    "esprima": "~0.9.9",
+    "esprima": "~1.0.0",
     "graceful-fs": "~1.1.10",
     "glob": "~3.1.12",
     "optimist": "~0.3.4"


### PR DESCRIPTION
Esprima 0.9.x was too old, it also still contains some parsing bugs.
